### PR TITLE
normalization at ARA, not KP

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ This README documents the current strawman architecture.  Changes must be made v
     3. ARA sends query messages to KPs
     4. KPs respond to ARAs with Message
 3. All communication between components conforms to the ReasonerAPI Message spec
-4. All nodes and edges in all messages (query and response) are normalized
-    1. SRI will provide tools for normalization
-    2. KPs must use https://nodenormalization-sri.renci.org/apidocs/ and https://edgenormalization-sri.renci.org/apidocs/
+4. KPs will send all nodes and edges in all messages in their "native" form, and the ARAs will be responsible for normalization
+    1. SRI will provide tools for normalization (including prototypes at https://nodenormalization-sri.renci.org/apidocs/ and https://edgenormalization-sri.renci.org/apidocs/
 5. ARAs and KPs may both score answers (provide scores in the message); ARAs are required to score answers
 6. KPs should not call other KPs.
 7. ARAs obtain biomedical data only via KPs (or other ARAs), not from locally-cached aggregated graphs or non-Translator data sources.


### PR DESCRIPTION
I think the job of normalization to BioLink Model should be done at the ARA level. KPs should store their data at the most granular/native level as possible. Since integration happens at the level of the ARA, that's where the lumping/normalization should occur IMO.