### PR TITLE
Clarify what sort of biomedical data ARAs will be required to obtain …

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This README documents the current strawman architecture.  Changes must be made v
     2. KPs must use https://nodenormalization-sri.renci.org/apidocs/ and https://edgenormalization-sri.renci.org/apidocs/
 5. ARAs and KPs may both score answers (provide scores in the message); ARAs are required to score answers
 6. KPs should not call other KPs.
-7. ARAs obtain biomedical data only via KPs (or other ARAs), not from locally-cached aggregated graphs or non-Translator data sources.
+7. ARAs obtain Message nodes and edges only via KPs (or other ARAs), not from locally-cached aggregated graphs or non-Translator data sources.
 8. Aggregated graphs must be created at the consortium level and exposed as a KP.
 9. Components that do not fulfill the responsibilities of KPs and ARAs can still be stand-alone elements of the architecture to provide particular functionality; such tools will use the Translator Message API whenever possible.
 10. Answer persistence will be the responsibility of the ARS


### PR DESCRIPTION
…from KPs or other translator resources.

In particular, while obtaining Message nodes and edges from Translator resources makes complete sense imho, ARAs frequently require additional information to perform reasoning. Examples include:

1. General use case: utilizing KS (and perhaps KP) data dumps to speed performance. 
    - Specific use case: NCBIeUtils is a slow API endpoint. When an ARA receives/creates a Message KG with many thousands of nodes and edges, the ARA may wish to annotate all pairs of nodes or all edges with co-occurrence frequency in PubMed literature. A locally cached version of PubMed/baseline stored in a local database causes these (tens of) thousands of queries to be executed in a performant fashion. Even though technically a Translator KP could be used to provide a faster API endpoint than NCBIeUtils for this purpose, the performance penalty would still be experienced. i.e. keep [these latency numbers](https://gist.github.com/hellerbarde/2843375) in mind. 
2. General use case: requiring locally aggregated graphs or other non-Translator resources for machine learning/reasoning purposes.
    - Specific use case: An ARA may need access to a specifically formatted graph in order to utilize  graph convolutional neural network methods (or node embedding methods for downstream traditional ML techniques). The ARA would use this information for link prediction, answer scoring, etc. purposes. It seems unreasonable to require a KP to provide this resource for a particular ARA.