### PR TITLE
Operations via KP registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ This README documents the current strawman architecture.  Changes must be made v
 12. A Translator Registry will expose programmatically accessible metadata about KPs and ARAs, and will provide testing and reports as part of a continuous integration framework.
     1. All KPs must be registered in the Translator Registry
     2. KPs must expose machine-readable metadata describing the node and edge types that they provide, initially via a /predicates endpoint
-    3. Non-KP, Non-ARA components will also be collected in the registry, in a manner yet to be determined.
+    3. KPs must expose machine-readable metadata describing the operations that they implement.
+    4. Non-KP, Non-ARA components will also be collected in the registry, in a manner yet to be determined.
 13. Both KPs and ARAs should acquire and transmit provenance information to the fullest possible extent
 
 ## Diagram

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This README documents the current strawman architecture.  Changes must be made v
 12. A Translator Registry will expose programmatically accessible metadata about KPs and ARAs, and will provide testing and reports as part of a continuous integration framework.
     1. All KPs must be registered in the Translator Registry
     2. KPs must expose machine-readable metadata describing the node and edge types that they provide, initially via a /predicates endpoint
-    3. KPs must expose machine-readable metadata describing the operations that they implement.
+    3. KPs must expose machine-readable metadata describing the operations that they implement.  The method for exposing this metadata may be dependent upon the interface method (SmartAPI, ReasonerAPI, or KGX file).
     4. Non-KP, Non-ARA components will also be collected in the registry, in a manner yet to be determined.
 13. Both KPs and ARAs should acquire and transmit provenance information to the fullest possible extent
 


### PR DESCRIPTION
A KP may provide many different operations: one-hop, arbitrary graph query, partial graph matches, adding edges to pre-existing graphs, annotation, etc...

The ReasonerAPI does not constrain the operation, but allows a KP to implement any of these (or any other) operation on the data.

For ARAs to use KPs effectively, they will need to know what a particular KP actually does (what operation(s) it performs).

This implies that we will need some shared catalog/description of operations, which can be updated over time as KPs innovate new operations.