### PR TITLE
Predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ This README documents the current strawman architecture.  Changes must be made v
    1. ARAs or other integration tools such as KGX will perform node identifier equivalence translations.
    1. The consortium will produce or adopt equivalent id sets, which will be shared across Translator tools.  Multiple Translator teams will contribute expertise to these sets, but that expertise will produce centralized results.
    1. SRI will provide tools for disseminating these equivalent identifiers, drawing on the prior work of multiple Translator teams.
+1. Edge Predicates
+   1. Relationships between entities (edges) have a predicate indicating the specific type of relationship between the entities.
+   1. The biolink model will contain a set of predicates used to bridge across pre-existing predicate vocabularies
+   1. The biolink model will designate a set of such vocabularies that can be mapped to biolink predciates.
+   1. Predicates in ReasonerAPI messages and KGX files must be chosen from the biolink model.
+   1. Responses from non-ReasonerAPI smartAPI-registered KP must provide sufficient information via the registry that clients can determine the predicate as an identifier from a biolink-designated vocabulary.
+   1. As a best practice, KPs should map ingested predicates to a biolink-designated vocabulary as precisely as possible, and rely on tools to convert these predicates into biolink predicates.
+   1. The SRI will provide mapping tools to perform this conversion.
 1. ARAs and KPs may both score answers (provide scores in the message); ARAs are required to score answers.
 1. KPs should not call other KPs.
 1. ARAs obtain biomedical data only via KPs (or other ARAs), not from locally-cached aggregated graphs or non-Translator data sources.
@@ -53,6 +61,7 @@ This README documents the current strawman architecture.  Changes must be made v
     1. Non-KP, Non-ARA components, such as normalizers, must also be registered and provide metadata appropriate to their API type.
     1. The SmartAPI Registry will provide a unified query system, returning information about all three API methods.  This query system will allow ARAs to locate the appropriate KPs.
     1. SRI will guarantee that metadata standards across the components allow such a unified query system.
+    1. The SmartAPI registry will allow components to find all KPs by querying for biolink predicates. The SmartAPI registry will allow components to query by predicate from biolink-understood vocabularies, and return KPs that provide such metadata.
 1. A continuous integration framework will consume metadata from the registry, and provide automated testing and reports.
 1. Both KPs and ARAs should acquire and transmit provenance information to the fullest possible extent.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This README documents the current strawman architecture.  Changes must be made v
 1. Edge Predicates
    1. Relationships between entities (edges) have a predicate indicating the specific type of relationship between the entities.
    1. The biolink model will contain a set of predicates (_biolink predicates_) used to bridge across pre-existing predicate vocabularies
-   1. The biolink model will designate a set of such vocabularies that can be mapped to biolink predciates. These vocabularies are called _biolink-mapped_.
+   1. The biolink model will designate a set of such vocabularies that can be mapped to biolink predicates. These vocabularies are called _biolink-mapped_.
    1. Predicates in ReasonerAPI messages and KGX files must be biolink predicates.
    1. Responses from non-ReasonerAPI smartAPI-registered KP must provide sufficient information via the registry that clients can determine the predicate as an identifier from a biolink-mapped vocabulary.
    1. As a best practice, KPs should map ingested predicates to a biolink-mapped vocabulary as precisely as possible, and rely on tools to convert these predicates into biolink predicates.

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ This README documents the current strawman architecture.  Changes must be made v
    1. SRI will provide tools for disseminating these equivalent identifiers, drawing on the prior work of multiple Translator teams.
 1. Edge Predicates
    1. Relationships between entities (edges) have a predicate indicating the specific type of relationship between the entities.
-   1. The biolink model will contain a set of predicates used to bridge across pre-existing predicate vocabularies
-   1. The biolink model will designate a set of such vocabularies that can be mapped to biolink predciates.
-   1. Predicates in ReasonerAPI messages and KGX files must be chosen from the biolink model.
-   1. Responses from non-ReasonerAPI smartAPI-registered KP must provide sufficient information via the registry that clients can determine the predicate as an identifier from a biolink-designated vocabulary.
-   1. As a best practice, KPs should map ingested predicates to a biolink-designated vocabulary as precisely as possible, and rely on tools to convert these predicates into biolink predicates.
+   1. The biolink model will contain a set of predicates (_biolink predicates_) used to bridge across pre-existing predicate vocabularies
+   1. The biolink model will designate a set of such vocabularies that can be mapped to biolink predciates. These vocabularies are called _biolink-mapped_.
+   1. Predicates in ReasonerAPI messages and KGX files must be biolink predicates.
+   1. Responses from non-ReasonerAPI smartAPI-registered KP must provide sufficient information via the registry that clients can determine the predicate as an identifier from a biolink-mapped vocabulary.
+   1. As a best practice, KPs should map ingested predicates to a biolink-mapped vocabulary as precisely as possible, and rely on tools to convert these predicates into biolink predicates.
    1. The SRI will provide mapping tools to perform this conversion.
 1. ARAs and KPs may both score answers (provide scores in the message); ARAs are required to score answers.
 1. KPs should not call other KPs.


### PR DESCRIPTION
Based on the recent Architecture call discussions.

In terms of best practices, those ingesting data should find a predicate that most precisely incorporates the meaning of the original source.   
SRI tools based on biolink mappings will convert those terms into biolink as precisely as possible.
TRAPI / KGX use biolink model predicates; can also transfer the underlying non-biolink predicate
smartAPI returns whatever it returns, but the metadata in the registry allows a mapping to a vocabulary, which can then be turned into biolink
Registry can be queries by biolink or original predicate.  Everything must be findable via biolink.