### PR TITLE
needed to rename

### DIFF
--- a/voting-members.md
+++ b/voting-members.md
@@ -1,5 +1,5 @@
 # Architecture-committee-Tracking-Voting
-Weekly meetings on Tuesday's, 2 pm ET.
+Weekly meetings on Tuesdays, 2 pm ET.
 After initial formation - roster should be maintained at the consortium level Translator Committees & Working Groups
 |Committee Member Name|Committee Member Team|Role|Email|
 |--|--|--|--|


### PR DESCRIPTION
There can't be both a README.md and a readme.md.
The README.md is the real readme; this one is a list of members that, IMO, probably shouldn't live in GitHub. This list is already in the google spreadsheet that was named but not linked here.