### PR TITLE
Inferred queries only use a single predicate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This README documents the current strawman architecture.  Changes must be made v
    1. KPs and ARAs must respond to lookup queries by treating the query as an exact database match
    1. ARAs may respond to inferred mode one-hops with relevant results beyond an exact database match; KPs may also provide this capability
    1. When answering an inferred-mode query, a component must also include lookup results.
+   1. inferred-mode queries must be one-hops with a single predicate.
 1. ReasonerAPI best practices:
    1. When an ARA obtains multiple edges with the same subject, predicate, qualifiers, object, and original/primary source from KPs, it should represent these as a single edge in the knowledge_graph component of a ReasonerAPI message.
    1. An ARA or a KP must not combine edges unless they contain the same subject, predicate, qualifiers, object, and original/primary source.


### PR DESCRIPTION
The current state is that many ARAs do not correctly handle multi-predicate inferred queries, and there are no clear use cases for such a thing.